### PR TITLE
Init

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "default" {
+  zone_id = "${var.zone_id}"
+  name    = "${var.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${var.elb_dns_name}"
+    zone_id                = "${var.elb_zone_id}"
+    evaluate_target_health = "${var.evaluate_target_health}"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "hostname" {
+  value = "${aws_route53_record.default.fqdn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,13 @@
+variable "name" {
+  default = "dns"
+}
+
+variable "zone_id" {}
+
+variable "elb_dns_name" {}
+
+variable "elb_zone_id" {}
+
+variable "evaluate_target_health" {
+  default = "false"
+}


### PR DESCRIPTION
## What
* Init vanity tf module
* Set vanity domains to be ALIAS records of AWS resources

## Why
* Encapsulate business logic of "vanity domains" in a module
* Vanity domains do not confirm to standard naming conventions of the cluster