### PR TITLE
Fix count calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+addons:
+  apt:
+    packages:
+      - git
+      - make
+      - curl
+
+install:
+  - make init
+
+script:
+  - make terraform:install
+  - make terraform:get-plugins
+  - make terraform:get-modules
+  - make terraform:lint
+  - make terraform:validate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL := /bin/bash
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+
+lint:
+	$(SELF) terraform:install terraform:get-modules terraform:get-plugins terraform:lint terraform:validate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-route53-alias [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-route53-alias.svg)](https://travis-ci.org/cloudposse/terraform-aws-route53-alias)
+# terraform-aws-route53-alias [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-route53-alias.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-route53-alias)
 
 Terraform module that implements "vanity" host names (e.g. `brand.com`) as `ALIAS` records to another Route53 DNS resource record (e.g. ELB/ALB, S3 Bucket Endpoint or CloudFront Distribution).
 Unlike `CNAME` records, the synthetic `ALIAS` record works with zone apexes.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-route53-alias
+# terraform-aws-route53-alias [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-route53-alias.svg)](https://travis-ci.org/cloudposse/terraform-aws-route53-alias)
 
 Terraform module that implements "vanity" host names (e.g. `brand.com`) as `ALIAS` records to another Route53 DNS resource record (e.g. ELB/ALB, S3 Bucket Endpoint or CloudFront Distribution).
 Unlike `CNAME` records, the synthetic `ALIAS` record works with zone apexes.
@@ -8,7 +8,7 @@ Unlike `CNAME` records, the synthetic `ALIAS` record works with zone apexes.
 
 This will define a `A` resource record for `www.example.com` as an alias of the `aws_elb.example.dns_name`.
 
-```hcl
+```terraform
 module "production_www" {
   source          = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=master"
   aliases         = ["www.example.com.", "static1.cdn.example.com.", "static2.cdn.example.com"]
@@ -18,22 +18,26 @@ module "production_www" {
 }
 ```
 
-
 ## Variables
-|  Name                     |  Default   |  Description                                                                            | Required |
-|:--------------------------|:----------:|:----------------------------------------------------------------------------------------|:--------:|
-| `aliases`                 | `[]`       | List of aliases                                                                         | Yes      |
-| `parent_zone_id`          | ``         | ID of the hosted zone to contain this record  (or specify `parent_zone_name`)           | Yes      |
-| `parent_zone_name`        | ``         | Name of the hosted zone to contain this record (or specify `parent_zone_id`)            | Yes      |
-| `target_dns_name`         | ``         | DNS-name of target resource (e.g. ALB,ELB)                                              | Yes      |
-| `target_zone_id`          | ``         | ID of target resource (e.g. ALB,ELB)                                                    | Yes      |
-| `evaluate_target_health`  | `false`    | Set to true if you want Route 53 to determine whether to respond to DNS queries         | No       |
+
+| Name                     | Default | Description                                                                     | Required |
+|:-------------------------|:-------:|:--------------------------------------------------------------------------------|:--------:|
+| `aliases`                |  `[]`   | List of aliases                                                                 |   Yes    |
+| `parent_zone_id`         |   ``    | ID of the hosted zone to contain this record  (or specify `parent_zone_name`)   |   Yes    |
+| `parent_zone_name`       |   ``    | Name of the hosted zone to contain this record (or specify `parent_zone_id`)    |   Yes    |
+| `target_dns_name`        |   ``    | DNS-name of target resource (e.g. ALB,ELB)                                      |   Yes    |
+| `target_zone_id`         |   ``    | ID of target resource (e.g. ALB,ELB)                                            |   Yes    |
+| `evaluate_target_health` | `false` | Set to true if you want Route 53 to determine whether to respond to DNS queries |    No    |
 
 
 ## Outputs
 
 | Name               | Description                                    |
-|:------------------ |:-----------------------------------------------|
-| `hostname`         | List of DNS-records                            |
+|:-------------------|:-----------------------------------------------|
+| `hostnames`        | List of DNS-records                            |
 | `parent_zone_id`   | ID of the hosted zone to contain this record   |
 | `parent_zone_name` | Name of the hosted zone to contain this record |
+
+## License
+
+Apache 2 License. See [`LICENSE`](LICENSE) for full details.

--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,12 @@
-resource "null_resource" "parent" {
-  triggers = {
-    zone_id   = "${format("%v", length(var.parent_zone_id) > 0 ? join(" ", data.aws_route53_zone.parent_by_zone_id.*.zone_id) : join(" ", data.aws_route53_zone.parent_by_zone_name.*.zone_id) )}"
-    zone_name = "${format("%v", length(var.parent_zone_id) > 0 ? join(" ", data.aws_route53_zone.parent_by_zone_id.*.name) : join(" ", data.aws_route53_zone.parent_by_zone_name.*.name) )}"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-data "aws_route53_zone" "parent_by_zone_id" {
-  count   = "${signum(length(var.parent_zone_id))}"
+data "aws_route53_zone" "default" {
+  count   = "${signum(length(compact(var.aliases)))}"
   zone_id = "${var.parent_zone_id}"
-}
-
-data "aws_route53_zone" "parent_by_zone_name" {
-  count = "${signum(length(var.parent_zone_name))}"
-  name  = "${var.parent_zone_name}"
+  name    = "${var.parent_zone_name}"
 }
 
 resource "aws_route53_record" "default" {
   count   = "${length(compact(var.aliases))}"
-  zone_id = "${null_resource.parent.triggers.zone_id}"
+  zone_id = "${data.aws_route53_zone.default.zone_id}"
   name    = "${element(compact(var.aliases), count.index)}"
   type    = "A"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,5 +7,5 @@ output "parent_zone_id" {
 }
 
 output "parent_zone_name" {
-  value = "${data.aws_route53_zone.default.*.zone_name}"
+  value = "${data.aws_route53_zone.default.*.name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,9 +3,9 @@ output "hostnames" {
 }
 
 output "parent_zone_id" {
-  value = "${null_resource.parent.triggers.zone_id}"
+  value = "${data.aws_route53_zone.default.*.zone_id}"
 }
 
 output "parent_zone_name" {
-  value = "${null_resource.parent.triggers.zone_name}"
+  value = "${data.aws_route53_zone.default.*.zone_name}"
 }


### PR DESCRIPTION
## What

* Fix count calculation 

## Why

* `value of 'count' cannot be computed`
* `count` can't be computed if DNS zone is created not yet
* https://github.com/cloudposse/terraform-aws-route53-alias/issues/8