### PR TITLE
When var.enabled = false the aws_route53_zone should not be created

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 data "aws_route53_zone" "default" {
-  count   = "${signum(length(compact(var.aliases)))}"
+  count   = "${var.enabled == "true" ? signum(length(compact(var.aliases))) : 0}"
   zone_id = "${var.parent_zone_id}"
   name    = "${var.parent_zone_name}"
 }


### PR DESCRIPTION
## What

Interpolate var.enabled inside the count structure of datasource aws_route53_zone

## Why

When the module is not 'enabled' it should not create the datasource for the zone.