### PR TITLE
Adds private_zone option to data lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Available targets:
 | ipv6_enabled | Set to true to enable an AAAA DNS record to be set as well as the A record | bool | `false` | no |
 | parent_zone_id | ID of the hosted zone to contain this record  (or specify `parent_zone_name`) | string | `` | no |
 | parent_zone_name | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | string | `` | no |
+| private_zone | Is this a private hosted zone? | bool | `false` | no |
 | target_dns_name | DNS name of target resource (e.g. ALB, ELB) | string | - | yes |
 | target_zone_id | ID of target resource (e.g. ALB, ELB) | string | - | yes |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -8,6 +8,7 @@
 | ipv6_enabled | Set to true to enable an AAAA DNS record to be set as well as the A record | bool | `false` | no |
 | parent_zone_id | ID of the hosted zone to contain this record  (or specify `parent_zone_name`) | string | `` | no |
 | parent_zone_name | Name of the hosted zone to contain this record (or specify `parent_zone_id`) | string | `` | no |
+| private_zone | Is this a private hosted zone? | bool | `false` | no |
 | target_dns_name | DNS name of target resource (e.g. ALB, ELB) | string | - | yes |
 | target_zone_id | ID of target resource (e.g. ALB, ELB) | string | - | yes |
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 data "aws_route53_zone" "default" {
-  count   = var.enabled ? signum(length(compact(var.aliases))) : 0
-  zone_id = var.parent_zone_id
-  name    = var.parent_zone_name
+  count        = var.enabled ? signum(length(compact(var.aliases))) : 0
+  zone_id      = var.parent_zone_id
+  name         = var.parent_zone_name
+  private_zone = var.private_zone
 }
 
 resource "aws_route53_record" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "parent_zone_name" {
   description = "Name of the hosted zone to contain this record (or specify `parent_zone_id`)"
 }
 
+variable "private_zone" {
+  type        = bool
+  default     = false
+  description = "Is this a private hosted zone?"
+}
+
 variable "target_dns_name" {
   type        = string
   description = "DNS name of target resource (e.g. ALB, ELB)"


### PR DESCRIPTION
## what

Adds private_zone option to data lookup. This maintains current behaviour by defaulting to false.

## why

Because sometimes we want to lookup a private hosted zone.