### PR TITLE
chore: bump aws provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
+    aws   = "~> 3.0"
     local = "~> 1.2"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 3.0"
+    aws   = "=> 2.0, < 4.0"
     local = "~> 1.2"
   }
 }


### PR DESCRIPTION
## what
* Allow AWS Provider v3.

## why
* A new major version was released.

