### PR TITLE
Fix: create records using `for_each` instead of `count`

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] |
-|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![1david5][1david5_avatar]][1david5_homepage]<br/>[1david5][1david5_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
+|---|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -354,6 +354,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [SweetOps_homepage]: https://github.com/SweetOps
   [SweetOps_avatar]: https://img.cloudposse.com/150x150/https://github.com/SweetOps.png
+  [1david5_homepage]: https://github.com/1david5
+  [1david5_avatar]: https://img.cloudposse.com/150x150/https://github.com/1david5.png
+  [korenyoni_homepage]: https://github.com/korenyoni
+  [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -73,3 +73,7 @@ contributors:
     github: "aknysh"
   - name: "Vladimir"
     github: "SweetOps"
+  - name: "1david5"
+    github: "1david5"
+  - name: "Yonatan Koren"
+    github: "korenyoni"

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ data "aws_route53_zone" "default" {
 }
 
 resource "aws_route53_record" "default" {
-  for_each        = module.this.enabled ? toset(compact(var.aliases)) : []
+  for_each = module.this.enabled ? toset(compact(var.aliases)) : []
   #bridgecrew:skip=BC_AWS_NETWORKING_60:All of the aliases are configurable via var.aliases and it is the user's responsibility to ensure that all of the resources are in the same account.
   #bridgecrew:skip=BC_AWS_GENERAL_95:All of the aliases are configurable via var.aliases and it is the user's responsibility to ensure that all of the aliases point to resources and not just IPv4 addresses.
   zone_id         = try(data.aws_route53_zone.default[0].zone_id, "")

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,9 @@ data "aws_route53_zone" "default" {
 }
 
 resource "aws_route53_record" "default" {
-  count           = module.this.enabled ? length(compact(var.aliases)) : 0
+  for_each        = module.this.enabled ? toset(compact(var.aliases)) : []
   zone_id         = try(data.aws_route53_zone.default[0].zone_id, "")
-  name            = compact(var.aliases)[count.index]
+  name            = each.key
   allow_overwrite = var.allow_overwrite
   type            = "A"
 
@@ -20,9 +20,9 @@ resource "aws_route53_record" "default" {
 }
 
 resource "aws_route53_record" "ipv6" {
-  count           = module.this.enabled && var.ipv6_enabled ? length(compact(var.aliases)) : 0
+  for_each        = module.this.enabled && var.ipv6_enabled ? toset(compact(var.aliases)) : []
   zone_id         = try(data.aws_route53_zone.default[0].zone_id, "")
-  name            = compact(var.aliases)[count.index]
+  name            = each.key
   allow_overwrite = var.allow_overwrite
   type            = "AAAA"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "hostnames" {
-  value       = aws_route53_record.default.*.fqdn
+  value       = try([for alias in var.aliases : aws_route53_record.default[alias].fqdn],[])
   description = "List of DNS records"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "hostnames" {
-  value       = try([for alias in var.aliases : aws_route53_record.default[alias].fqdn],[])
+  value       = try([for alias in var.aliases : aws_route53_record.default[alias].fqdn], [])
   description = "List of DNS records"
 }
 


### PR DESCRIPTION
## what
* Modify `default` and `ipv6` `aws_route53_record` resources to use `for_each` instead of `count`.

## why
* Prevent destroying and recreating DNS records when removing elements from `aliases` list.

