### PR TITLE
Modify defaults for parent from empty strings to null.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -5,13 +5,13 @@ variable "aliases" {
 
 variable "parent_zone_id" {
   type        = string
-  default     = ""
+  default     = null
   description = "ID of the hosted zone to contain this record  (or specify `parent_zone_name`)"
 }
 
 variable "parent_zone_name" {
   type        = string
-  default     = ""
+  default     = null
   description = "Name of the hosted zone to contain this record (or specify `parent_zone_id`)"
 }
 


### PR DESCRIPTION
Due to, it seems some changes to the `aws_route53_zone` data source in provider version 5.51.0, it seems using empty strings here causes an issue where the following error is received.

```
│ Error: Invalid combination of arguments
│
│   with
module.cloudfront.module.cloudfront_distribution.module.route53_alias.data.aws_route53_zone.default[0],
│   on
.terraform/modules/cloudfront.cloudfront_distribution.route53_alias/main.tf
line 4, in data "aws_route53_zone" "default":
│    4:   name         = var.parent_zone_name
│
│ "name": only one of `name,zone_id` can be specified, but
`name,zone_id`
│ were specified.
```

By using null in place of empty strings here, the validation seems to pass without issue. This can be validated by trying to use this module with 5.51.0, and finding that no matter which is provided both are interpreted as having been provided, triggering the error.

[history of data source
file](https://github.com/hashicorp/terraform-provider-aws/commits/0750cf2ce20f2b1cc6144176ce33593ba53b0220/internal/service/route53/zone_data_source.go)